### PR TITLE
ci(dependabot): fix package-ecosystem value

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@
 
 version: 2
 updates:
-  - package-ecosystem: "go" # See documentation for possible values
+  - package-ecosystem: "gomod" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"


### PR DESCRIPTION
* Fixed `"go"` --> `"gomod"`.

Closes https://github.com/zimmermanncode/go-require/issues/4 